### PR TITLE
Enabled the init script to be managed by chkconfig

### DIFF
--- a/init_kibana
+++ b/init_kibana
@@ -1,6 +1,20 @@
 #!/bin/sh
 #
-# /etc/init.d/kibana -- startup script for kibana4
+# kibana -- startup script for kibana4
+#
+# chkconfig: - 85 15
+# processname: kibana
+# pidfile: /var/run/kibana.pid
+# description: Kibana is a webui to visualize data
+#
+### BEGIN INIT INFO
+# Provides: kibana
+# Required-Start: $local_fs $remote_fs $network
+# Required-Stop: $local_fs $remote_fs $network
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: start and stop kibana
+### END INIT INFO
 #
 #
 . /etc/init.d/functions


### PR DESCRIPTION
```
[root@box init.d]# chkconfig --add kibana                                                                                                                           
service kibana does not support chkconfig
```

I made my changes and could then add kibana to chkconfig

```
[root@box init.d]# chkconfig --add kibana                                                                                                                           
[root@box init.d]# chkconfig --list | grep kibana                                                                                                                   
kibana          0:off   1:off   2:on    3:on    4:on    5:on    6:off
```
